### PR TITLE
fix ip add

### DIFF
--- a/install/Questions
+++ b/install/Questions
@@ -634,7 +634,7 @@ DisplaySurvey() {
             OIFS=$IFS
             IFS=$','
             for sIp in ${sValue}; do
-                sIp="$(echo "${sIp}" | sed 's/^ //g;s/\s+$//g;s/\/32//g;')"
+                sIp="$(echo "${sIp// /}" | sed 's/^ //g;s/\s+$//g;s/\/32//g;')"
                 sTmp="$(gfnValidateIP "${sIp}")"
                 if [ -n "${sTmp}" ]; then
                     if [ -z "${sCheckIp}" ]; then


### PR DESCRIPTION
lors d'une première install, au moment ou il posé la question : Quelles sont les adresses IP publiques que vous souhaitez ajouter dès maintenant ?
en entrant mon IP à ajouter à la whitelist + confirmation, il repose la même questions en boucle.
ça bloque l'install de MySB.